### PR TITLE
Aktualisiert API Client auf HttpClient Nutzung

### DIFF
--- a/Source/MediaAccount.Client.Console/IntializeClient.cs
+++ b/Source/MediaAccount.Client.Console/IntializeClient.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Net.Http;
 
 namespace Krowiorsch.MediaAccount;
 
 public class IntializeClient
 {
-    public MediaAccountClientV2 GetClientV2(string apiKey, Uri baseUri) => new(apiKey, baseUri);
+    public MediaAccountClientV2 GetClientV2(HttpClient client) => new(client);
     public MediaAccountClientV3 GetClientV3(string apiKey, Uri baseUri) => new(apiKey, baseUri);
 }

--- a/Source/MediaAccount.Client.Console/MediaAccount.Client.Console.csproj
+++ b/Source/MediaAccount.Client.Console/MediaAccount.Client.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net472</TargetFrameworks>
+		<TargetFrameworks>net8</TargetFrameworks>
 		<Version>1.0.0</Version>
 		<Company>Landau Media GmbH &amp; CoKG</Company>
 		<OutputType>Exe</OutputType>

--- a/Source/MediaAccount.Client.Console/Program.cs
+++ b/Source/MediaAccount.Client.Console/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Krowiorsch.MediaAccount.RequestBuilder;
 using Serilog;
@@ -57,7 +59,16 @@ public static class Program
     {
             
         var duration = Stopwatch.StartNew();
-        var client = new IntializeClient().GetClientV2(key, null);
+        using var httpClient = new HttpClient()
+        {
+            DefaultRequestHeaders =
+            {
+                Authorization = new AuthenticationHeaderValue("Bearer", "")
+            },
+            BaseAddress = new Uri("http://api.media-account.de")
+        };
+        
+        var client = new IntializeClient().GetClientV2(httpClient);
 
         var count = 0;
         var response = client.CreateScroll(RequestDateType.Updatedatum, DateTime.Now.Date.AddDays(-14),

--- a/Source/MediaAccount.Client/MediaAccountClientV2.cs
+++ b/Source/MediaAccount.Client/MediaAccountClientV2.cs
@@ -1,14 +1,14 @@
-﻿using Krowiorsch.MediaAccount.Model;
+﻿using System.Net.Http.Headers;
+using Krowiorsch.MediaAccount.Model;
 using Krowiorsch.MediaAccount.Model.V2;
 using Krowiorsch.MediaAccount.RequestBuilder;
 using Newtonsoft.Json;
 
 namespace Krowiorsch.MediaAccount;
 
-public class MediaAccountClientV2 : IDisposable, IMediaAccountClient<Article>
+public class MediaAccountClientV2 : IMediaAccountClient<Article>
 {
     readonly string _userAgent;
-    readonly string _apiKey;
     readonly HttpClient _httpClient;
 
     readonly ArticleListDeserializer _deserializer = new();
@@ -16,12 +16,27 @@ public class MediaAccountClientV2 : IDisposable, IMediaAccountClient<Article>
     /// <summary>Erzeugt einen Client für den Gegebenen ApiKey. Wenn kein Endpunkt angegeben wird, wird das Produktivsystem benutzt.</summary>
     /// <param name="apiKey">Api key</param>
     /// <param name="baseEndpoint">alternativer Endpoint</param>
+    [Obsolete("Use HttpClient Construtkru")]
     public MediaAccountClientV2(string apiKey, Uri? baseEndpoint = null)
     {
         baseEndpoint ??= Globals.EndpointProduction;
 
-        _apiKey = apiKey;
-        _httpClient = new HttpClient { BaseAddress = baseEndpoint };
+        _httpClient = new HttpClient
+        {
+            BaseAddress = baseEndpoint,
+            DefaultRequestHeaders =
+            {
+                Authorization = new AuthenticationHeaderValue("api_key", apiKey)
+            }
+        };
+        _userAgent = $"MediaAccountClient ({GetType().Assembly.GetName().Version})";
+    }
+
+    public MediaAccountClientV2(HttpClient client)
+    {
+        _httpClient = client ?? throw new ArgumentNullException(nameof(client));
+        _httpClient.BaseAddress ??= Globals.EndpointProduction;
+        if (!_httpClient.DefaultRequestHeaders.Contains("api_key")) throw new ArgumentException("Api key is missing in the HttpClient headers.");
         _userAgent = $"MediaAccountClient ({GetType().Assembly.GetName().Version})";
     }
 
@@ -38,7 +53,7 @@ public class MediaAccountClientV2 : IDisposable, IMediaAccountClient<Article>
 
     public ArticleListScroll<Article> CreateScroll(RequestDateType dateType, DateTime start, DateTime end, int batchSize = 50, string? additionalParameters = null)
     {
-        var request = new V2ArticleRequestBuilder(_httpClient.BaseAddress, _apiKey).CreateInitialUrl(dateType, start, end, batchSize, additionalParameters);
+        var request = new V2ArticleRequestBuilder(_httpClient.BaseAddress).CreateInitialUrl(dateType, start, end, batchSize, additionalParameters);
         return new ArticleListScroll<Article>(this, MoveScroll) { NextPageLink = request };
     }
 
@@ -48,7 +63,7 @@ public class MediaAccountClientV2 : IDisposable, IMediaAccountClient<Article>
         if (string.IsNullOrEmpty(scroll.NextPageLink))
             return false;
 
-        var request = new ArticleScrollBuilder(_httpClient.BaseAddress, _apiKey).Create(scroll);
+        var request = new ArticleScrollBuilder(_httpClient.BaseAddress).Create(scroll);
         var result = await _httpClient.SendAsync(request).ConfigureAwait(false);
         result.EnsureSuccessStatusCode();
         var json = await result.Content.ReadAsStringAsync();
@@ -59,18 +74,9 @@ public class MediaAccountClientV2 : IDisposable, IMediaAccountClient<Article>
     HttpRequestMessage Create(string endpoint)
     {
         var message = new HttpRequestMessage(HttpMethod.Get, endpoint);
-        message.Headers.Add("api_key", _apiKey);
-        message.Headers.Add("User-Agent", _userAgent);
+        message.Headers.UserAgent.ParseAdd(_userAgent);
         message.Headers.Add("Accept", "application/json");
 
         return message;
     }
-
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
-    protected virtual void Dispose(bool disposable) => _httpClient.Dispose();
 }

--- a/Source/MediaAccount.Client/MediaAccountClientV3.cs
+++ b/Source/MediaAccount.Client/MediaAccountClientV3.cs
@@ -40,7 +40,7 @@ public class MediaAccountClientV3 : IDisposable, IMediaAccountClient<Meldung>
 
     public ArticleListScroll<Meldung> CreateScroll(RequestDateType dateType, DateTime start, DateTime end, int batchSize = 50, string? additionalParameters = null)
     {
-        var request = new V3ArticleRequestBuilder(_httpClient.BaseAddress, _apiKey).CreateInitialUrl(dateType, start, end, batchSize, additionalParameters);
+        var request = new V3ArticleRequestBuilder(_httpClient.BaseAddress).CreateInitialUrl(dateType, start, end, batchSize, additionalParameters);
         return new ArticleListScroll<Meldung>(this, MoveScroll) { NextPageLink = request };
     }
 
@@ -49,7 +49,7 @@ public class MediaAccountClientV3 : IDisposable, IMediaAccountClient<Meldung>
         if (string.IsNullOrEmpty(scroll.NextPageLink))
             return false;
 
-        var request = new ArticleScrollBuilder(_httpClient.BaseAddress, _apiKey).Create(scroll);
+        var request = new ArticleScrollBuilder(_httpClient.BaseAddress).Create(scroll);
         var result = await _httpClient.SendAsync(request).ConfigureAwait(false);
         result.EnsureSuccessStatusCode();
         var json = await result.Content.ReadAsStringAsync();

--- a/Source/MediaAccount.Client/RequestBuilder/ArticleScrollBuilder.cs
+++ b/Source/MediaAccount.Client/RequestBuilder/ArticleScrollBuilder.cs
@@ -6,8 +6,8 @@ namespace Krowiorsch.MediaAccount.RequestBuilder
 {
     public class ArticleScrollBuilder : BaseRequestBuilder
     {
-        public ArticleScrollBuilder(Uri endpoint, string apiKey)
-            : base(endpoint, apiKey)
+        public ArticleScrollBuilder(Uri endpoint)
+            : base(endpoint)
         {
         }
 

--- a/Source/MediaAccount.Client/RequestBuilder/BaseRequestBuilder.cs
+++ b/Source/MediaAccount.Client/RequestBuilder/BaseRequestBuilder.cs
@@ -5,20 +5,17 @@ namespace Krowiorsch.MediaAccount.RequestBuilder
     public class BaseRequestBuilder
     {
         protected Uri _endpoint;
-        readonly string _apiKey;
         readonly string _userAgent;
 
-        protected BaseRequestBuilder(Uri endpoint, string apiKey)
+        protected BaseRequestBuilder(Uri endpoint)
         {
             _endpoint = endpoint;
-            _apiKey = apiKey;
             _userAgent = $"MediaAccountClient ({GetType().Assembly.GetName().Version})";
         }
 
         protected HttpRequestMessage CreateGet()
         {
             var message = new HttpRequestMessage(HttpMethod.Get, _endpoint);
-            message.Headers.Add("api_key", _apiKey);
             message.Headers.Add("User-Agent", _userAgent);
             message.Headers.Add("Accept", "application/json");
 

--- a/Source/MediaAccount.Client/RequestBuilder/V2ArticleRequestBuilder.cs
+++ b/Source/MediaAccount.Client/RequestBuilder/V2ArticleRequestBuilder.cs
@@ -4,8 +4,8 @@ namespace Krowiorsch.MediaAccount.RequestBuilder
 {
     public class V2ArticleRequestBuilder : BaseRequestBuilder
     {
-        public V2ArticleRequestBuilder(Uri endpoint, string apiKey)
-            : base(endpoint, apiKey)
+        public V2ArticleRequestBuilder(Uri endpoint)
+            : base(endpoint)
         {
         }
 
@@ -31,8 +31,8 @@ namespace Krowiorsch.MediaAccount.RequestBuilder
 
     public class V3ArticleRequestBuilder : BaseRequestBuilder
     {
-        public V3ArticleRequestBuilder(Uri endpoint, string apiKey)
-            : base(endpoint, apiKey)
+        public V3ArticleRequestBuilder(Uri endpoint)
+            : base(endpoint)
         {
         }
 


### PR DESCRIPTION
- Entfernt API-Key aus dem Client-Konstruktor
- Führt HttpClient mit Auth Header ein
- Aktualisiert Ziel-Framework auf .NET 8
- Entfernt IDisposable aus MediaAccountClientV2
